### PR TITLE
[Fix] Endpoints Access Policy

### DIFF
--- a/api/src/main/java/com/katsshura/cupcake/api/security/WebSecurityConfig.java
+++ b/api/src/main/java/com/katsshura/cupcake/api/security/WebSecurityConfig.java
@@ -68,7 +68,8 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
                 .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS).and()
                 .authorizeRequests()
                 .antMatchers(HttpMethod.GET,"/ping/**").permitAll()
-                .antMatchers(HttpMethod.GET,"/user/**").permitAll()
+                .antMatchers(HttpMethod.POST,"/user").permitAll()
+                .antMatchers(HttpMethod.POST,"/user/signin").permitAll()
                 .antMatchers(HttpMethod.POST,"/user/**").permitAll()
                 .and().authorizeRequests().anyRequest().authenticated();
 

--- a/api/src/main/java/com/katsshura/cupcake/api/security/WebSecurityConfig.java
+++ b/api/src/main/java/com/katsshura/cupcake/api/security/WebSecurityConfig.java
@@ -70,7 +70,7 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
                 .antMatchers(HttpMethod.GET,"/ping/**").permitAll()
                 .antMatchers(HttpMethod.POST,"/user").permitAll()
                 .antMatchers(HttpMethod.POST,"/user/signin").permitAll()
-                .antMatchers(HttpMethod.POST,"/user/**").permitAll()
+                .antMatchers(HttpMethod.GET,"/product/**").permitAll()
                 .and().authorizeRequests().anyRequest().authenticated();
 
         http.addFilterBefore(authenticationJwtTokenFilter(), UsernamePasswordAuthenticationFilter.class);


### PR DESCRIPTION
### Changes
- Only endpoints regarding user registration and user login are available without the need of JWT Token.
- The endpoints on user controller regarding payments requires JWT Authentication
- GET endpoints on product controller are now public, since we don't require as business rule the user to be authenticated in this part of the flow.
- Post endpoints on product controller still requires a JWT Token